### PR TITLE
Allow releasing to both entitlements and entitlements-app gem names

### DIFF
--- a/entitlements-app.gemspec
+++ b/entitlements-app.gemspec
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 Gem::Specification.new do |s|
-  s.name = "entitlements-app"
+  s.name = ENV['GEM_NAME'] ? ENV['GEM_NAME'] : 'entitlements-app'
+  puts "Gem name: #{s.name}"
+
   s.version = File.read("VERSION").chomp
   s.summary = "git-managed LDAP group configurations"
   s.description = "The Ruby Gem that Powers Entitlements - GitHub's Identity and Access Management System"

--- a/entitlements-app.gemspec
+++ b/entitlements-app.gemspec
@@ -2,8 +2,6 @@
 
 Gem::Specification.new do |s|
   s.name = ENV['GEM_NAME'] ? ENV['GEM_NAME'] : 'entitlements-app'
-  puts "Gem name: #{s.name}"
-
   s.version = File.read("VERSION").chomp
   s.summary = "git-managed LDAP group configurations"
   s.description = "The Ruby Gem that Powers Entitlements - GitHub's Identity and Access Management System"

--- a/script/release
+++ b/script/release
@@ -10,8 +10,9 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 cd ${DIR}
 
 # Build a new gem archive.
+rm -rf entitlements-*.gem
 
-rm -rf entitlements-app-*.gem
+GEM_NAME='entitlements' gem build -q entitlements-app.gemspec
 gem build -q entitlements-app.gemspec
 
 # Make sure we're on the main branch.
@@ -36,5 +37,6 @@ git fetch -t origin
 
 # Tag it and bag it.
 
-gem push entitlements-app-*.gem && git tag "$tag" &&
-  git push origin main && git push origin "$tag"
+gem push entitlements-app-*.gem && rm -f entitlements-app-*.gem
+gem push entitlements-*.gem && rm -f entitlements-*.gem
+git tag "$tag" &&  git push origin main &&  git push origin "$tag"


### PR DESCRIPTION
![DALL·E 2022-08-15 15 16 13 - comic book cover of two face programming a computer](https://user-images.githubusercontent.com/6259/184710949-4668a41b-32df-4b80-8b8e-4a694516ab2b.png)

_(dall-e 2: "comic book cover of two face programming a computer")_

We have used the `entitlements` gem name internally, but we have also published this open source project to `entitlements-app` and have gems released that way. Here is an update to our `script/release` + gemspec logic to allow pushing the same versions to both ruby gem names.

cc @DanHoerst 