### PR TITLE
Fix the Build action to run on macos again

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14-arm64]
+        os: [ubuntu-latest, macos-14]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
 
-      - uses: ruby/setup-ruby@250fcd6a742febb1123a77a841497ccaa8b9e939 # pin@v1.152.0
+      - uses: ruby/setup-ruby@1198b074305f9356bd56dd4b311757cc0dab2f1c # pin@v1.175.1
         with:
           bundler-cache: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-14]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-14-arm64]
     runs-on: ${{ matrix.os }}
 
     steps:


### PR DESCRIPTION
From https://github.com/ruby/setup-ruby/issues/577#issuecomment-2084308727:
> Recently, macos-latest seems to have become macos-14 running on M1.
> CIs using older versions of ruby are failing because they can't be downloaded.

This PR:
- ~~changes the referenced macos runner to `macos-14-arm64`~~
- updates our usage of the action to 1.175.1, which ~~permits that new reference~~ supports `macos-local` pointing to `macos-14`.