### PR TITLE
Attest Build Provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ on:
 permissions:
   contents: write
   packages: write
+  id-token: write
+  attestations: write
 
 jobs:
   release:
@@ -39,6 +41,10 @@ jobs:
         # builds the gem and saves the version to GITHUB_ENV
       - name: build
         run: echo "GEM_VERSION=$(gem build ${{ env.GEM_NAME }}.gemspec 2>&1 | grep Version | cut -d':' -f 2 | tr -d " \t\n\r")" >> $GITHUB_ENV
+      
+      - uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "${{ env.GEM_NAME }}-${{ env.GEM_VERSION }}.gem"
 
       - name: publish to GitHub packages
         run: |

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    entitlements-app (0.3.2)
+    entitlements-app (0.3.3)
       concurrent-ruby (= 1.1.9)
       faraday (~> 2.0)
       net-ldap (~> 0.17)

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -2,6 +2,6 @@
 
 module Entitlements
   module Version
-    VERSION = "0.3.2"
+    VERSION = "0.3.3"
   end
 end


### PR DESCRIPTION
# Attest Build Provenance :lock:

> _Artifact attestations enable you to increase the supply chain security of your builds by establishing where and how your software was built._

This pull request publishes build attestations for the `entitlements-app` Gem. This allows us and all downstream consumers to use the built in gh cli command to securely validate when/where the Gem was built and that GitHub (the trusted source) created it.

## Example :camera_flash:

Here is an example of how users of this gem can verify the gem after this PR lands:

```console
$ gh attestation verify entitlements-app-X.X.X.gem --owner github
```

> Read more about artifact attestations [here](https://docs.github.com/en/actions/security-guides/using-artifact-attestations-to-establish-provenance-for-builds) :books: