### PR TITLE
do not use a cache on release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,12 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: ruby/setup-ruby@32110d4e311bd8996b2a82bf2a43b714ccc91777 # pin@v1.221.0
         with:
-          bundler-cache: true
+          bundler-cache: false
 
       - name: bootstrap
         run: script/bootstrap


### PR DESCRIPTION
This pull request modifies the `release` workflow to explicitly prevent the usage of a cache on release builds 