### PR TITLE
Fixed https://github.com/github/entitlements-app/issues/68

### DIFF
--- a/lib/entitlements/data/groups/calculated/text.rb
+++ b/lib/entitlements/data/groups/calculated/text.rb
@@ -294,7 +294,7 @@ module Entitlements
                 result[key]["&="] ||= []
 
                 # Semicolon predicates
-                if key == "description"
+                if key == "description" || key.start_with?("metadata_")
                   result[key][operator] << { key: val }
                 else
                   result[key][operator] << parsed_predicate(val)

--- a/spec/unit/entitlements/data/groups/calculated/text_spec.rb
+++ b/spec/unit/entitlements/data/groups/calculated/text_spec.rb
@@ -203,6 +203,12 @@ describe Entitlements::Data::Groups::Calculated::Text do
       subject = described_class.new(filename: filename)
       expect(subject.modifiers).to eq("expiration"=>"2043-01-01")
     end
+
+    it "raises an error if a modifier has additional settings" do
+      filename = fixture("ldap-config/expiration/additional-settings.txt")
+      message = "In #{filename}, the key modifier_expiration cannot have additional setting(s) \"expiration\"!"
+      expect { described_class.new(filename: filename).modifiers }.to raise_error(message)
+    end
   end
 
   describe "#rules" do

--- a/spec/unit/entitlements/data/groups/calculated/text_spec.rb
+++ b/spec/unit/entitlements/data/groups/calculated/text_spec.rb
@@ -183,10 +183,11 @@ describe Entitlements::Data::Groups::Calculated::Text do
       expect(subject.metadata).to eq("kittens" => "awesome", "puppies" => "young dogs")
     end
 
-    it "raises an error if expiration is given to metadata" do
-      filename = fixture("ldap-config/metadata/expiration.txt")
-      message = "In #{filename}, the key metadata_kittens cannot have additional setting(s) \"expiration\"!"
-      expect { described_class.new(filename: filename) }.to raise_error(message)
+    it "does not raise an error when metadata values contain semicolons" do
+      filename = fixture("ldap-config/metadata/semicolon.txt")
+      expect { described_class.new(filename: filename) }.not_to raise_error
+      subject = described_class.new(filename: filename)
+      expect(subject.metadata).to eq("kittens" => "awesome", "justification" => "Need access; for project work")
     end
   end
 

--- a/spec/unit/fixtures/ldap-config/expiration/additional-settings.txt
+++ b/spec/unit/fixtures/ldap-config/expiration/additional-settings.txt
@@ -1,0 +1,3 @@
+description = This has a modifier with extra settings
+username = blackmanx
+expiration = 2043-01-01; expiration = 2044-01-01

--- a/spec/unit/fixtures/ldap-config/metadata/semicolon.txt
+++ b/spec/unit/fixtures/ldap-config/metadata/semicolon.txt
@@ -1,0 +1,5 @@
+description = Lots of metadata here
+username = BlackManx
+username = RAGAMUFFIn
+metadata_kittens = awesome
+metadata_justification = Need access; for project work


### PR DESCRIPTION
# Fixes <https://github.com/github/entitlements-app/issues/68>

## Problem

The text file parser treats `;` as a predicate separator on all lines, including `metadata_*` lines. When a metadata value contains a semicolon (e.g. `metadata_continuing_business_justification = Need access; for project work`), the parser calls `parsed_predicate`, which raises:

ArgumentError: Unparseable semicolon predicate "for project work"

## Fix

Extend the existing `description` bypass in `parsed_data` to also cover `metadata_` prefixed keys. These are free-form text values (like descriptions) and should not have their semicolons parsed as predicates.

## Changes

- **`lib/entitlements/data/groups/calculated/text.rb`** - Add `key.start_with?("metadata_")` to the condition that bypasses `parsed_predicate`
- **`spec/.../text_spec.rb`** - Replace the test that expected an error on metadata semicolons with one that asserts no error is raised and the value is preserved
- **`spec/.../text_spec.rb`** - Removed outdated spec. Expirations on metadata will be treated like regular text.
- **`spec/fixtures/.../semicolon.txt`** - New fixture with a semicolon in a metadata value
