### PR TITLE
Optimize entitlement calculation hot paths

### DIFF
--- a/lib/entitlements/data/groups/calculated.rb
+++ b/lib/entitlements/data/groups/calculated.rb
@@ -96,12 +96,14 @@ module Entitlements
               # Use the ruleset to build the group.
               options = { skip_broken_references: skip_broken_references }
 
-              Entitlements.cache[:file_objects][filename] ||= ruleset(filename: filename, config: cfg_obj, options: options)
+              cache_key = file_object_key(filename)
+              Entitlements.cache[:file_objects][cache_key] ||= ruleset(filename: filename, config: cfg_obj, options: options)
+              file_object = Entitlements.cache[:file_objects][cache_key]
               @groups_cache[group_dn] = Entitlements::Models::Group.new(
                 dn: group_dn,
-                members: Entitlements.cache[:file_objects][filename].modified_filtered_members,
-                description: Entitlements.cache[:file_objects][filename].description,
-                metadata: Entitlements.cache[:file_objects][filename].metadata.merge("_filename" => filename)
+                members: file_object.modified_filtered_members,
+                description: file_object.description,
+                metadata: file_object.metadata.merge("_filename" => filename)
               )
               result.add group_dn
             end
@@ -217,6 +219,10 @@ module Entitlements
 
           clazz = Kernel.const_get(FILE_EXTENSIONS[ext])
           clazz.new(filename: filename, config: config, options: options)
+        end
+
+        def self.file_object_key(filename)
+          filename.sub(/\.\w+\z/, "")
         end
 
         #########################

--- a/lib/entitlements/data/groups/calculated/base.rb
+++ b/lib/entitlements/data/groups/calculated/base.rb
@@ -117,28 +117,11 @@ module Entitlements
               result = members.dup
               filters.reject { |_, filter_val| filter_val == :all }.each do |filter_name, filter_val|
                 filter_cfg = Entitlements::Data::Groups::Calculated.filters_index[filter_name]
+                next unless filter_applies?(filter_cfg.fetch(:config, {}))
+
                 clazz = filter_cfg.fetch(:class)
                 obj = clazz.new(filter: filter_val, config: filter_cfg.fetch(:config, {}))
-                # If excluded_paths is set, ignore any of those excluded paths
-                unless filter_cfg[:config]["excluded_paths"].nil?
-                  # if the filename is not in any of the excluded paths, filter it
-                  unless filter_cfg[:config]["excluded_paths"].any? { |excluded_path| filename.include?(excluded_path) }
-                    result.reject! { |member| obj.filtered?(member) }
-                  end
-                end
-
-                # if included_paths is set, filter only files at those included paths
-                unless filter_cfg[:config]["included_paths"].nil?
-                  # if the filename is in any of the included paths, filter it
-                  if filter_cfg[:config]["included_paths"].any? { |included_path| filename.include?(included_path) }
-                    result.reject! { |member| obj.filtered?(member) }
-                  end
-                end
-
-                # if neither included_paths nor excluded_paths are set, filter normally
-                if filter_cfg[:config]["included_paths"].nil? and filter_cfg[:config]["excluded_paths"].nil?
-                  result.reject! { |member| obj.filtered?(member) }
-                end
+                result.reject! { |member| obj.filtered?(member) }
               end
               result
             end
@@ -169,6 +152,17 @@ module Entitlements
           private
 
           attr_reader :config, :options
+
+          def filter_applies?(filter_config)
+            included_paths = filter_config["included_paths"]
+            excluded_paths = filter_config["excluded_paths"]
+
+            return true if included_paths.nil? && excluded_paths.nil?
+            return true if included_paths&.any? { |included_path| filename.include?(included_path) }
+            return true if excluded_paths&.none? { |excluded_path| filename.include?(excluded_path) }
+
+            false
+          end
 
           # Common method that takes a given list of members and applies the modifiers.
           # Used to calculated `modified_members` and `modified_filtered_members`.

--- a/lib/entitlements/data/groups/calculated/filters/base.rb
+++ b/lib/entitlements/data/groups/calculated/filters/base.rb
@@ -49,20 +49,13 @@ module Entitlements
             # member - Entitlements::Models::Person object
             #
             # Returns true if a member of the filter conditions, false otherwise.
-            Contract Entitlements::Models::Person => C::Bool
             def member_of_filter?(member)
-              # First handle all username entries, regardless of order, because we do not
-              # have to mess around with reading groups for those.
-              filter.reject { |filter_val| filter_val =~ /\// }.each do |filter_val|
-                return true if filter_val.downcase == member.uid.downcase
-              end
+              return true if filter_usernames.include?(member.uid.downcase)
 
-              # Now handle all group entries.
-              filter.select { |filter_val| filter_val =~ /\// }.each do |filter_val|
+              filter_groups.each do |filter_val|
                 return true if member_of_named_group?(member, filter_val)
               end
 
-              # If we get here there was no match.
               false
             end
 
@@ -73,17 +66,26 @@ module Entitlements
             # group_ref - Optionally a string with a reference to a group to look up
             #
             # Returns true if a member of the group, false otherwise.
-            Contract Entitlements::Models::Person, String => C::Bool
             def member_of_named_group?(member, group_ref)
               Entitlements.cache[:member_of_named_group] ||= {}
               Entitlements.cache[:member_of_named_group][group_ref] ||= begin
                 member_set = Entitlements::Data::Groups::Calculated::Rules::Group.matches(
                   value: group_ref,
                 )
-                member_set.map { |person| person.uid.downcase }
+                member_set.each_with_object(Set.new) { |person, result| result.add(person.uid.downcase) }
               end
 
               Entitlements.cache[:member_of_named_group][group_ref].include?(member.uid.downcase)
+            end
+
+            def filter_usernames
+              @filter_usernames ||= filter.each_with_object(Set.new) do |filter_val, result|
+                result.add(filter_val.downcase) unless filter_val.include?("/")
+              end
+            end
+
+            def filter_groups
+              @filter_groups ||= filter.select { |filter_val| filter_val.include?("/") }
             end
           end
         end

--- a/lib/entitlements/data/groups/calculated/filters/member_of_group.rb
+++ b/lib/entitlements/data/groups/calculated/filters/member_of_group.rb
@@ -17,7 +17,6 @@ module Entitlements
             # member - Entitlements::Models::Person object
             #
             # Returns true if the person is to be filtered out, false otherwise.
-            Contract Entitlements::Models::Person => C::Bool
             def filtered?(member)
               return false if filter == :all
               return false unless member_of_named_group?(member, config.fetch("group"))

--- a/lib/entitlements/data/groups/calculated/rules/group.rb
+++ b/lib/entitlements/data/groups/calculated/rules/group.rb
@@ -63,9 +63,11 @@ module Entitlements
                   # the cache without going any further. Otherwise, create a new object for the group
                   # reference and calculate them.
                   unless Entitlements.cache[:file_objects][filebase_with_path]
-                    clazz = Kernel.const_get(FILE_EXTENSIONS[ext])
-                    Entitlements.cache[:file_objects][filebase_with_path] = clazz.new(
+                    target_config = Entitlements.config.fetch("groups", {})[ou] || {}
+                    Entitlements.cache[:file_objects][filebase_with_path] = Entitlements::Data::Groups::Calculated.ruleset(
                       filename: "#{filebase_with_path}.#{ext}",
+                      config: target_config,
+                      options: options,
                     )
                     if Entitlements.cache[:file_objects][filebase_with_path].members == :calculating
                       next if matching_files.size > 1

--- a/lib/entitlements/extras/ldap_group/filters/member_of_ldap_group.rb
+++ b/lib/entitlements/extras/ldap_group/filters/member_of_ldap_group.rb
@@ -16,7 +16,6 @@ module Entitlements
           # member - Entitlements::Models::Person object
           #
           # Returns true if the person is to be filtered out, false otherwise.
-          Contract Entitlements::Models::Person => C::Bool
           def filtered?(member)
             return false if filter == :all
             return false unless member_of_ldap_group?(member, config.fetch("ldap_group"))
@@ -31,14 +30,13 @@ module Entitlements
           # group_dn - LDAP distinguished name of the group
           #
           # Returns true if a member of the group, false otherwise.
-          Contract Entitlements::Models::Person, String => C::Bool
           def member_of_ldap_group?(member, group_dn)
             Entitlements.cache[:member_of_ldap_group] ||= {}
             Entitlements.cache[:member_of_ldap_group][group_dn] ||= begin
               member_set = Entitlements::Extras::LDAPGroup::Rules::LDAPGroup.matches(value: group_dn)
-              member_set.map { |person| person.uid.downcase }
+              member_set.each_with_object(Set.new) { |person, result| result.add(person.uid.downcase) }
             rescue Entitlements::Data::Groups::GroupNotFoundError
-              []
+              Set.new
             end
 
             Entitlements.cache[:member_of_ldap_group][group_dn].include?(member.uid.downcase)

--- a/spec/unit/entitlements/data/groups/calculated/base_spec.rb
+++ b/spec/unit/entitlements/data/groups/calculated/base_spec.rb
@@ -109,6 +109,33 @@ describe Entitlements::Data::Groups::Calculated::Base do
     end
   end
 
+  describe "#advanced_filters - included and excluded paths" do
+    let(:file) { fixture("ldap-config/filters/included-path-filters.yaml") }
+    let(:obj) { Entitlements::Data::Groups::Calculated::YAML.new(filename: file, config: config) }
+    let(:config) { { "base" => "ou=Felines,ou=Groups,dc=kittens,dc=net" } }
+
+    it "checks each member once when both path rules select the file" do
+      filter_cfg = {
+        class: Entitlements::Data::Groups::Calculated::Filters::MemberOfGroup,
+        config: {
+          "group" => "internal/workday/on-leave",
+          "included_paths" => ["ldap-config/filters"],
+          "excluded_paths" => ["fake-path/is-fake"]
+        }
+      }
+      Entitlements::Data::Groups::Calculated.register_filter("included-paths", filter_cfg)
+      russianblue = people_obj.read["russianblue"]
+      blackmanx = people_obj.read["blackmanx"]
+
+      filter = instance_double(Entitlements::Data::Groups::Calculated::Filters::MemberOfGroup)
+      expect(Entitlements::Data::Groups::Calculated::Filters::MemberOfGroup).to receive(:new).and_return(filter)
+      expect(filter).to receive(:filtered?).with(russianblue).once.and_return(false)
+      expect(filter).to receive(:filtered?).with(blackmanx).once.and_return(false)
+
+      expect(obj.filtered_members).to eq(Set.new([blackmanx, russianblue]))
+    end
+  end
+
   describe "#modified_members" do
     before(:each) do
       allow_any_instance_of(described_class).to receive(:modifiers_constant).and_return(%w[expiration])

--- a/spec/unit/entitlements/data/groups/calculated/rules/group_spec.rb
+++ b/spec/unit/entitlements/data/groups/calculated/rules/group_spec.rb
@@ -95,6 +95,24 @@ describe Entitlements::Data::Groups::Calculated::Rules::Group do
         answer_set = Set.new(result.map { |name| people_obj.read[name] })
         expect(obj.members).to eq(answer_set)
       end
+
+      it "reuses recursively created file objects during top-level calculation" do
+        Entitlements.config_file = fixture("config.yaml")
+        path = fixture("ldap-config/nested_groups")
+        allow(Entitlements::Util::Util).to receive(:path_for_group).with("nested_groups").and_return(path)
+
+        obj.members
+        recursively_created = cache[:file_objects].dup
+        Entitlements::Data::Groups::Calculated.read_all(
+          "nested_groups",
+          { "base" => "ou=Nested,ou=Groups,dc=kittens,dc=net" }
+        )
+
+        recursively_created.each do |key, value|
+          expect(cache[:file_objects][key]).to equal(value)
+        end
+        expect(cache[:file_objects].keys).to all(satisfy { |filename| File.extname(filename).empty? })
+      end
     end
 
     context "for a wildcard group that does not self-reference" do

--- a/spec/unit/entitlements/data/groups/calculated_spec.rb
+++ b/spec/unit/entitlements/data/groups/calculated_spec.rb
@@ -50,6 +50,19 @@ describe Entitlements::Data::Groups::Calculated do
       expect(simple1.members.map { |i| i.uid }).to include(ragamuffin)
     end
 
+    it "caches file objects by their path without an extension" do
+      allow(Entitlements::Util::Util).to receive(:path_for_group).with(ou_key)
+        .and_return(fixture("ldap-config/#{ou_key}"))
+
+      described_class.read_all(ou_key, cfg_obj)
+
+      expect(cache[:file_objects].keys).to all(satisfy { |filename| File.extname(filename).empty? })
+      expect(cache[:file_objects].keys).to contain_exactly(
+        fixture("ldap-config/simple/simple1"),
+        fixture("ldap-config/simple/simple2")
+      )
+    end
+
     it "skips over a subdirectory in the main OU" do
       allow(Entitlements::Util::Util).to receive(:path_for_group).with("nested_ou")
         .and_return(fixture("ldap-config/nested_ou"))


### PR DESCRIPTION
## Summary

This fixes several compounding calculation-path issues discovered with a production-shaped synthetic entitlement benchmark.

## Issue breakdown

| Issue | Existing behavior | Fix |
|---|---|---|
| Contracts in per-person predicates | Runtime contracts wrapped `filtered?` and membership helper calls for every candidate member. Contract reflection and validation dominated allocations. | Remove contracts from these trusted internal predicates while retaining contracts at constructors, configuration boundaries, and broader calculation APIs. |
| Duplicate filter execution | When a filter had both `included_paths` and `excluded_paths`, a selected file could execute the identical `reject!` pass twice. | Resolve path applicability once and execute at most one rejection pass per filter. |
| Repeated filter parsing | Username and group filter entries were split with `reject` and `select` for every candidate member. | Partition and normalize filter entries once per filter object. |
| Linear membership lookup | Cached group members were stored in arrays and checked with `Array#include?` for every candidate. | Store normalized usernames in a `Set` for constant-time lookup. |
| Inconsistent file-object cache keys | Top-level calculations cached by full filename while recursive references cached by extensionless path. The same group was instantiated and filtered repeatedly. | Use one canonical extensionless key for both paths. |
| Recursive rules bypassed target configuration | Recursive references directly instantiated a class without the target OU configuration or calculation options, bypassing normal ruleset validation. | Construct recursive objects through `Calculated.ruleset` with target configuration and options. |

## Correctness impact

- Include/exclude path semantics are preserved, but the filter cannot run twice.
- Recursive and top-level references now share the same calculated object and modifier/filter caches.
- Recursive references now enforce target OU settings such as `allowed_types`.
- Group membership matching remains case-insensitive.

## Performance

Ruby 3.3.12, synthetic production-shaped calculation, three unprofiled runs where noted:

| Version | Calculation time | Allocated objects | Peak RSS |
|---|---:|---:|---:|
| Before | 64.99s median | 422.9M | ~615 MB |
| After | 19.44s median | 75.8M | ~554 MB |

This reduces calculation time by approximately **70%**, allocations by **82%**, and peak memory by about **10%**. Duplicate calculation log events fell from **8,401 to 8**.

## Validation

- `bundle exec rspec spec/unit` — 538 examples, 0 failures, 100% unit coverage
- RuboCop on all changed Ruby files — no offenses
- complete synthetic entitlement calculation — successful

The acceptance suite requires its Docker/LDAP environment and is not runnable directly on the host checkout.
